### PR TITLE
Add upload_apk option

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,20 +28,22 @@ Call `amazon_app_submission` in your Fastfile.
     client_id: "<CLIENT_ID>",
     client_secret: "<CLIENT_SECRET>",
     app_id: "<APP_ID>",
-    apk_path: "<APK_PATH>",
     # Optional
+    apk_path: "<APK_PATH>",
+    upload_apk: true,
     changelogs_folder_path:  "<CHANGELOG_PATH>",
     upload_changelogs: false,
     submit_for_review: false
   )
 ```
 
-| param | default value | optional | description 
+| param | default value | optional | description
 |:----------|:-----------:|:-----------:|:-----------:|
-client_id | - | false | getting client id from Amazon developer console dashboard 
-client_secret | - | false | getting client secret from Amazon developer console dashboard 
-app_id | - | false | getting app id from Amazon developer console dashboard 
-apk_path | - | false | link where you storing the release apk 
+client_id | - | false | getting client id from Amazon developer console dashboard
+client_secret | - | false | getting client secret from Amazon developer console dashboard
+app_id | - | false | getting app id from Amazon developer console dashboard
+apk_path | - | true | link where you storing the release apk
+upload_apk  | true  | true  | set this to false to not upload an apk. can be used to only upload changelogs
 changelogs_folder_path | "" | true | setting the folder path where you have the change logs with different file for each language, if language file not found it will use default.txt
 upload_changelogs | false | true | updating the change logs for the upcoming version
 submit_for_review | false | true | submit the uploaded APK to the store  
@@ -60,9 +62,9 @@ Spanish | es-ES.txt
 Spanish-Mexican | es-MX.txt
 Other | default.txt  
 
-## Testing 
+## Testing
 
-For testing the plugin locally you have to get `client_id`, `client_secret`, `app_id` and `apk_path` in fastlane/Fastfile 
+For testing the plugin locally you have to get `client_id`, `client_secret`, `app_id` and `apk_path` in fastlane/Fastfile
 please check Usage step to see how you can get them.
 
 Then call `bundle exec fastlane test` in your terminal

--- a/lib/fastlane/plugin/amazon_app_submission/actions/amazon_app_submission_action.rb
+++ b/lib/fastlane/plugin/amazon_app_submission/actions/amazon_app_submission_action.rb
@@ -57,7 +57,7 @@ module Fastlane
       end
 
       def self.authors
-        ["mohammedhemaid"]
+        ["mohammedhemaid", "saschagraeff"]
       end
 
       def self.return_value

--- a/lib/fastlane/plugin/amazon_app_submission/actions/amazon_app_submission_action.rb
+++ b/lib/fastlane/plugin/amazon_app_submission/actions/amazon_app_submission_action.rb
@@ -53,7 +53,7 @@ module Fastlane
       end
 
       def self.description
-        "fast-lane plugin for Amazon App Submissions"
+        "Fastlane plugin for Amazon App Submissions"
       end
 
       def self.authors
@@ -66,7 +66,7 @@ module Fastlane
 
       def self.details
         # Optional:
-        "fast-lane plugin for Amazon App Submissions"
+        "Fastlane plugin for Amazon App Submissions"
       end
 
       def self.available_options

--- a/lib/fastlane/plugin/amazon_app_submission/helper/amazon_app_submission_helper.rb
+++ b/lib/fastlane/plugin/amazon_app_submission/helper/amazon_app_submission_helper.rb
@@ -87,10 +87,10 @@ module Fastlane
 
         res = http.request(req)
         if !res.body.nil?
-        apks = JSON.parse(res.body)
-        firstAPK = apks[0]
-        apk_id = firstAPK['id']
-        return apk_id
+          apks = JSON.parse(res.body)
+          firstAPK = apks.kind_of?(Array) ? apks[0] : apks
+          apk_id = firstAPK['id']
+          return apk_id
         end
       end
 


### PR DESCRIPTION
This adds a new optional parameter `:upload_apk`. When set to `false` (default `true`), no steps are taken to upload an apk.

The intention of this parameter is to allow uploading changelogs while skipping the apk upload.

The `:apk_path` option is now optional so it can be omitted when `:upload_apk` is `false`.

In addition, we had a problem where amazon would respond with a single json object rather than an array after requesting `edits/<edit_id>/apks`. Since the official documentation still hints at an array being returned, a small change now checks whether an array was returned, and just uses the object otherwise.