### PR TITLE
Apk upload read/write timeout + surface potential errors

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,9 @@ Call `amazon_app_submission` in your Fastfile.
     upload_apk: true,
     changelogs_path:  "<CHANGELOG_PATH>",
     upload_changelogs: false,
-    submit_for_review: false
+    submit_for_review: false,
+    read_timeout: 1000,
+    write_timeout: 1000,
   )
 ```
 
@@ -47,6 +49,8 @@ upload_apk  | true  | true  | set this to false to not upload an apk. can be use
 changelogs_path | "" | true | setting the folder path where you have the change logs with different file for each language, if language file not found it will use default.txt
 upload_changelogs | false | true | updating the change logs for the upcoming version
 submit_for_review | false | true | submit the uploaded APK to the store  
+read_timeout | 1000 | true | read timeout in seconds for the apk upload process
+submit_for_review | 1000 | true | write timeout in seconds for the apk upload process
 
 * changelogs folder files name should be:
 

--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ changelogs_path | "" | true | setting the folder path where you have the change 
 upload_changelogs | false | true | updating the change logs for the upcoming version
 submit_for_review | false | true | submit the uploaded APK to the store  
 read_timeout | 1000 | true | read timeout in seconds for the apk upload process
-submit_for_review | 1000 | true | write timeout in seconds for the apk upload process
+write_timeout | 1000 | true | write timeout in seconds for the apk upload process
 
 * changelogs folder files name should be:
 

--- a/README.md
+++ b/README.md
@@ -34,8 +34,7 @@ Call `amazon_app_submission` in your Fastfile.
     changelogs_path:  "<CHANGELOG_PATH>",
     upload_changelogs: false,
     submit_for_review: false,
-    read_timeout: 1000,
-    write_timeout: 1000,
+    transport_timeout: 1000,
   )
 ```
 
@@ -49,8 +48,7 @@ upload_apk  | true  | true  | set this to false to not upload an apk. can be use
 changelogs_path | "" | true | setting the folder path where you have the change logs with different file for each language, if language file not found it will use default.txt
 upload_changelogs | false | true | updating the change logs for the upcoming version
 submit_for_review | false | true | submit the uploaded APK to the store  
-read_timeout | 1000 | true | read timeout in seconds for the apk upload process
-write_timeout | 1000 | true | write timeout in seconds for the apk upload process
+transport_timeout | 1000 | true | read/write timeout in seconds for the apk upload process
 
 * changelogs folder files name should be:
 

--- a/lib/fastlane/plugin/amazon_app_submission/actions/amazon_app_submission_action.rb
+++ b/lib/fastlane/plugin/amazon_app_submission/actions/amazon_app_submission_action.rb
@@ -10,7 +10,7 @@ module Fastlane
         token = Helper::AmazonAppSubmissionHelper.get_token(params[:client_id], params[:client_secret])
 
         if token.nil?
-          UI.message("Cannot retrieve token, please check your client ID and client secret")
+          UI.user_error!("Cannot retrieve token, please check your client ID and client secret", show_github_issues: false)
         end
 
         UI.message("Getting current edit")
@@ -23,7 +23,7 @@ module Fastlane
         end  
 
         if current_edit_id.nil?
-        UI.error("Creating new edit failed!")
+        UI.crash!("Creating new edit failed!")
         return
         end
 
@@ -31,11 +31,16 @@ module Fastlane
           UI.message("Get current apk id")
           current_apk_id = Helper::AmazonAppSubmissionHelper.get_current_apk_id(token, params[:app_id], current_edit_id)
 
-          UI.message("Get current apk ETag")
-          current_apk_eTag = Helper::AmazonAppSubmissionHelper.get_current_apk_etag(token, params[:app_id], current_edit_id, current_apk_id)
+          if current_apk_id.nil?
+            UI.message("No apk found. Uploading new apk.")
+            Helper::AmazonAppSubmissionHelper.uploadNewApk(token, params[:app_id], current_edit_id, params[:apk_path], params[:read_timeout], params[:write_timeout])
+          else
+            UI.message("Get current apk ETag")
+            current_apk_eTag = Helper::AmazonAppSubmissionHelper.get_current_apk_etag(token, params[:app_id], current_edit_id, current_apk_id)
 
-          UI.message("Replacing the apk with apk from #{params[:apk_path]}")
-          replace_apk_response_code, replace_apk_response =  Helper::AmazonAppSubmissionHelper.replaceExistingApk(token, params[:app_id], current_edit_id, current_apk_id, current_apk_eTag, params[:apk_path], params[:read_timeout], params[:write_timeout])
+            UI.message("Replacing the apk with apk from #{params[:apk_path]}")
+            Helper::AmazonAppSubmissionHelper.replaceExistingApk(token, params[:app_id], current_edit_id, current_apk_id, current_apk_eTag, params[:apk_path], params[:read_timeout], params[:write_timeout])
+          end
         end
 
         if params[:upload_changelogs]
@@ -43,18 +48,12 @@ module Fastlane
           Helper::AmazonAppSubmissionHelper.update_listings( token, params[:app_id],current_edit_id, params[:changelogs_path], params[:changelogs_path])
         end
 
-        if params[:upload_apk]
-          if replace_apk_response_code == '200'
-            if params[:submit_for_review]
-               UI.message("Submitting to Amazon app store")
-               Helper::AmazonAppSubmissionHelper.commit_edit(token, params[:app_id], current_edit_id, edit_eTag)
-            end
-          else
-            UI.error("Amazon app submission failed at replacing the apk error code #{replace_apk_response_code} and error respones #{replace_apk_response}")
-            return
-          end
+        if params[:upload_apk] && params[:submit_for_review]
+          UI.message("Submitting to Amazon app store")
+          Helper::AmazonAppSubmissionHelper.commit_edit(token, params[:app_id], current_edit_id, edit_eTag)
         end
-        UI.message("Amazon app submission finished successfully!")
+
+        UI.success("Amazon app submission finished successfully!")
       end
 
       def self.description
@@ -71,7 +70,7 @@ module Fastlane
 
       def self.details
         # Optional:
-        "Fastlane plugin for Amazon App Submissions"
+        "Creates an Upcoming Version for an Amazon Appstore app, uploads the data, then and submits the new Version for review"
       end
 
       def self.available_options

--- a/lib/fastlane/plugin/amazon_app_submission/actions/amazon_app_submission_action.rb
+++ b/lib/fastlane/plugin/amazon_app_submission/actions/amazon_app_submission_action.rb
@@ -33,13 +33,13 @@ module Fastlane
 
           if current_apk_id.nil?
             UI.message("No apk found. Uploading new apk.")
-            Helper::AmazonAppSubmissionHelper.uploadNewApk(token, params[:app_id], current_edit_id, params[:apk_path], params[:read_timeout], params[:write_timeout])
+            Helper::AmazonAppSubmissionHelper.uploadNewApk(token, params[:app_id], current_edit_id, params[:apk_path], params[:transport_timeout])
           else
             UI.message("Get current apk ETag")
             current_apk_eTag = Helper::AmazonAppSubmissionHelper.get_current_apk_etag(token, params[:app_id], current_edit_id, current_apk_id)
 
             UI.message("Replacing the apk with apk from #{params[:apk_path]}")
-            Helper::AmazonAppSubmissionHelper.replaceExistingApk(token, params[:app_id], current_edit_id, current_apk_id, current_apk_eTag, params[:apk_path], params[:read_timeout], params[:write_timeout])
+            Helper::AmazonAppSubmissionHelper.replaceExistingApk(token, params[:app_id], current_edit_id, current_apk_id, current_apk_eTag, params[:apk_path], params[:transport_timeout])
           end
         end
 
@@ -128,19 +128,13 @@ module Fastlane
                                     optional: true,
                                         type: Boolean),
 
-            FastlaneCore::ConfigItem.new(key: :read_timeout,
-                                    env_name: "AMAZON_APP_SUBMISSION_READ_TIMEOUT",
-                                 description: "Read timeout in seconds for the apk upload process",
+            FastlaneCore::ConfigItem.new(key: :transport_timeout,
+                                    env_name: "AMAZON_APP_SUBMISSION_TRANSPORT_TIMEOUT",
+                                 description: "Read/write timeout in seconds for the apk upload process",
                                default_value: 1000,
                                     optional: true,
                                         type: Fixnum),
 
-            FastlaneCore::ConfigItem.new(key: :write_timeout,
-                                    env_name: "AMAZON_APP_SUBMISSION_WRITE_TIMEOUT",
-                                 description: "Write timeout in seconds for the apk upload process",
-                               default_value: 1000,
-                                    optional: true,
-                                        type: Fixnum)
 
           # FastlaneCore::ConfigItem.new(key: :your_option,
           #                         env_name: "AMAZON_APP_SUBMISSION_YOUR_OPTION",

--- a/lib/fastlane/plugin/amazon_app_submission/actions/amazon_app_submission_action.rb
+++ b/lib/fastlane/plugin/amazon_app_submission/actions/amazon_app_submission_action.rb
@@ -35,7 +35,7 @@ module Fastlane
           current_apk_eTag = Helper::AmazonAppSubmissionHelper.get_current_apk_etag(token, params[:app_id], current_edit_id, current_apk_id)
 
           UI.message("Replacing the apk with apk from #{params[:apk_path]}")
-          replace_apk_response_code, replace_apk_response =  Helper::AmazonAppSubmissionHelper.replaceExistingApk(token, params[:app_id], current_edit_id, current_apk_id, current_apk_eTag, params[:apk_path])
+          replace_apk_response_code, replace_apk_response =  Helper::AmazonAppSubmissionHelper.replaceExistingApk(token, params[:app_id], current_edit_id, current_apk_id, current_apk_eTag, params[:apk_path], params[:read_timeout], params[:write_timeout])
         end
 
         if params[:upload_changelogs]
@@ -50,7 +50,7 @@ module Fastlane
                Helper::AmazonAppSubmissionHelper.commit_edit(token, params[:app_id], current_edit_id, edit_eTag)
             end
           else
-            UI.message("Amazon app submission failed at replacing the apk error code #{replace_apk_response_code} and error respones #{replace_apk_response}")
+            UI.error("Amazon app submission failed at replacing the apk error code #{replace_apk_response_code} and error respones #{replace_apk_response}")
             return
           end
         end
@@ -127,7 +127,21 @@ module Fastlane
                                  description: "Amazon App Submission submit for review",
                                default_value: false,
                                     optional: true,
-                                        type: Boolean)
+                                        type: Boolean),
+
+            FastlaneCore::ConfigItem.new(key: :read_timeout,
+                                    env_name: "AMAZON_APP_SUBMISSION_READ_TIMEOUT",
+                                 description: "Read timeout in seconds for the apk upload process",
+                               default_value: 1000,
+                                    optional: true,
+                                        type: Fixnum),
+
+            FastlaneCore::ConfigItem.new(key: :write_timeout,
+                                    env_name: "AMAZON_APP_SUBMISSION_WRITE_TIMEOUT",
+                                 description: "Write timeout in seconds for the apk upload process",
+                               default_value: 1000,
+                                    optional: true,
+                                        type: Fixnum)
 
           # FastlaneCore::ConfigItem.new(key: :your_option,
           #                         env_name: "AMAZON_APP_SUBMISSION_YOUR_OPTION",

--- a/lib/fastlane/plugin/amazon_app_submission/helper/amazon_app_submission_helper.rb
+++ b/lib/fastlane/plugin/amazon_app_submission/helper/amazon_app_submission_helper.rb
@@ -116,7 +116,7 @@ module Fastlane
         return res.header['ETag']
       end
 
-      def self.replaceExistingApk(token, app_id, edit_id, apk_id, eTag, apk_path, read_timeout, write_timeout, should_retry = true)
+      def self.replaceExistingApk(token, app_id, edit_id, apk_id, eTag, apk_path, transport_timeout, should_retry = true)
 
         replace_apk_path = "/v1/applications/#{app_id}/edits/#{edit_id}/apks/#{apk_id}/replace"
         local_apk = File.open(apk_path, "r").read
@@ -128,8 +128,8 @@ module Fastlane
         uri = URI(replace_apk_url)
         http = Net::HTTP.new(uri.host, uri.port)
         http.use_ssl = true
-        http.write_timeout = write_timeout
-        http.read_timeout = read_timeout
+        http.write_timeout = transport_timeout
+        http.read_timeout = transport_timeout
         req = Net::HTTP::Put.new(
             uri.path,
             'Authorization' => token,
@@ -145,7 +145,7 @@ module Fastlane
         # Retry again if replace failed
         if res.code == '412' && should_retry
           UI.important("replacing the apk failed, retrying uploading it again...")
-          retry_code, retry_res = replaceExistingApk(token, app_id, edit_id, apk_id, eTag, apk_path, read_timeout, write_timeout, false)
+          retry_code, retry_res = replaceExistingApk(token, app_id, edit_id, apk_id, eTag, apk_path, transport_timeout, false)
           UI.crash!(retry_res) unless retry_code == '200'
         end
         return res.code, replace_apk_response
@@ -171,7 +171,7 @@ module Fastlane
         result_json = JSON.parse(res.body)
       end
 
-      def self.uploadNewApk(token, app_id, edit_id, apk_path, read_timeout, write_timeout)
+      def self.uploadNewApk(token, app_id, edit_id, apk_path, transport_timeout)
 
         add_apk_path = "/v1/applications/#{app_id}/edits/#{edit_id}/apks/upload"
         add_apk_url = BASE_URL + add_apk_path
@@ -180,8 +180,8 @@ module Fastlane
         uri = URI(add_apk_url)
         http = Net::HTTP.new(uri.host, uri.port)
         http.use_ssl = true
-        http.write_timeout = write_timeout
-        http.read_timeout = read_timeout
+        http.write_timeout = transport_timeout
+        http.read_timeout = transport_timeout
         req = Net::HTTP::Post.new(
             uri.path,
             'Authorization' => token,

--- a/lib/fastlane/plugin/amazon_app_submission/helper/amazon_app_submission_helper.rb
+++ b/lib/fastlane/plugin/amazon_app_submission/helper/amazon_app_submission_helper.rb
@@ -25,8 +25,9 @@ module Fastlane
         auth_token = "Bearer #{result_json['access_token']}"
 
         if result_json['error'] == 'invalid_scope'
-          UI.message("It seems that the provided security profile is not attached to the App Submission API")
+          UI.crash!("It seems that the provided security profile is not attached to the App Submission API")
         end
+        UI.crash!(res.body) unless res.code == '200'
 
         return auth_token
       end
@@ -46,7 +47,7 @@ module Fastlane
         )
 
         res = http.request(req)
-        UI.error(res.body) unless res.code == '200'
+        UI.crash!(res.body) unless res.code == '200'
         current_edit = JSON.parse(res.body)
 
         return current_edit['id']
@@ -67,7 +68,6 @@ module Fastlane
         )
 
         res = http.request(req)
-        UI.error(res.body) unless res.code == '200'
         current_edit = JSON.parse(res.body)
 
         return current_edit['id'], res.header['ETag']
@@ -88,7 +88,6 @@ module Fastlane
         )
 
         res = http.request(req)
-        UI.error(res.body) unless res.code == '200'
 
         if !res.body.nil?
           apks = JSON.parse(res.body)
@@ -113,7 +112,7 @@ module Fastlane
         )
 
         res = http.request(req)
-        UI.error(res.body) unless res.code == '200'
+        UI.crash!(res.body) unless res.code == '200'
         return res.header['ETag']
       end
 
@@ -143,12 +142,11 @@ module Fastlane
         res = http.request(req)
         
         replace_apk_response = JSON.parse(res.body)
-        UI.error(res.body) unless res.code == '200'
         # Retry again if replace failed
         if res.code == '412' && should_retry
-          UI.message("replacing the apk failed, retrying uploading it again...")
-          replaceExistingApk(token, app_id, edit_id, apk_id, eTag, apk_path, false)
-          return
+          UI.important("replacing the apk failed, retrying uploading it again...")
+          retry_code, retry_res = replaceExistingApk(token, app_id, edit_id, apk_id, eTag, apk_path, read_timeout, write_timeout, false)
+          UI.crash!(retry_res) unless retry_code == '200'
         end
         return res.code, replace_apk_response
       end
@@ -169,6 +167,7 @@ module Fastlane
             )
 
         res = http.request(req)
+        UI.crash!(res.body) unless res.code == '200'
         result_json = JSON.parse(res.body)
       end
 
@@ -191,7 +190,7 @@ module Fastlane
 
         req.body = local_apk
         res = http.request(req)
-        UI.error(res.body) unless res.code == '200'
+        UI.crash!(res.body) unless res.code == '200'
         result_json = JSON.parse(res.body)
       end
 
@@ -210,7 +209,7 @@ module Fastlane
         )
 
         res = http.request(req)
-        UI.error(res.body) unless res.code == '200'
+        UI.crash!(res.body) unless res.code == '200'
         listings_response = JSON.parse(res.body)
 
         # Iterating over the languages for getting the ETag.
@@ -227,7 +226,7 @@ module Fastlane
               'Content-Type' => 'application/json'
           )
         etag_response = http.request(req)
-        UI.error(etag_response) unless etag_response.code == '200'
+        UI.crash!(etag_response) unless etag_response.code == '200'
         etag = etag_response.header['Etag']
 
         recent_changes = find_changelog(
@@ -253,7 +252,7 @@ module Fastlane
 
         req.body = listing.to_json
         res = http.request(req)
-        UI.error(res.body) unless res.code == '200'
+        UI.crash!(res.body) unless res.code == '200'
         listings_response = JSON.parse(res.body)
         end
       end
@@ -293,7 +292,7 @@ module Fastlane
             )
 
         res = http.request(req)
-        UI.error(res.body) unless res.code == '200'
+        UI.crash!(res.body) unless res.code == '200'
         result_json = JSON.parse(res.body)
       end
     end


### PR DESCRIPTION
- Add extra parameter to set _read_ and _write_ timeouts to let users adjust them when uploading big apks (over 500mb)
    - recommended value for large apks: `transport_timeout:1800`
- Throw errors using `UI.crash` so users invoking the plugin via one off runs do exit with non zero exit code whenever there is an error
    ```
    [bundle exec] fastlane run amazon_app_submission [params...]
    ```
- Fix a bug when second try of `replaceExistingApk` didn't return new values
- Add support to upload the apk when there is no attached one on the Edit. This usually happens when the user manually deletes the apk from the web portal.